### PR TITLE
Add check that prevents infinite loop of state updates on layout measure

### DIFF
--- a/lib/PopoverElement.js
+++ b/lib/PopoverElement.js
@@ -94,6 +94,9 @@ class PopoverElement extends Component {
   }
 
   measureLayout = ({ nativeEvent: { layout: { width, height } } }) => {
+    if (width === this.state.width && height === this.state.height) {
+      return;
+    }
     this.setState({ width, height }, () => this.computeStyles(this.props));
   };
 


### PR DESCRIPTION
For some reason on Android tablets `onLayout` called infinitely, that caused popover item to be not clickable, as it re-rendering every frame.